### PR TITLE
Update directory permissions

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -21,7 +21,7 @@ class suricata::config {
     ensure  => directory,
     owner   => $::suricata::user,
     group   => 'root',
-    mode    => '0750',
+    mode    => '0755',
     require => $usr_require,
     before  => File["${::suricata::config_dir}/${::suricata::config_name}"],
   }


### PR DESCRIPTION
Allow file listening of configuration and log directories for non-root users, this doesn't expose any sensitive information and allows directory traversal without sudo.