### PR TITLE
Manage package/service + linting fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,12 @@ This module includes a resource for adding scripts. This resource adds the scrip
 Choose whether suricata should be present, absent, latest or version
 Defaults to 'present'
 
+#### `package_manage`
+
+Choose whether this module should handle installation of Suricata
+
+Defaults to true
+
 #### `package_name`
 
 Name of suricata package in repo
@@ -193,6 +199,12 @@ Defaults to 'suricata.yaml'
 Directory of suricatas log files
 
 Defaults to '/var/log/suricata'
+
+### `service_manage`
+
+Choose whether this module should manage Suricata service
+
+Defaults to true
 
 #### `service_ensure`
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,9 +1,10 @@
-
 suricata::ensure: "present"
+suricata::package_manage: true
 suricata::package_name: "suricata"
 suricata::config_dir: "/etc/suricata"
 suricata::config_name: "suricata.yaml"
 suricata::log_dir: "/var/log/suricata"
+suricata::service_manage: true
 suricata::service_name: "suricata"
 suricata::service_ensure: "running"
 suricata::service_enable: true

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,6 +8,10 @@
 #   Choose whether suricata should be present, absent, latest or version
 #   Defaults to 'present'
 #
+# [*package_manage*]
+#   Choose whether this module will install Suricata service
+#   Defaults to true
+# 
 # [*package_name*]
 #   Name of suricata package in repo
 #   Defaults to 'suricata'
@@ -24,6 +28,10 @@
 #   Directory of suricatas log files
 #   Defaults to '/var/log/suricata'
 #
+# [*service_manage*]
+#   Choose whether this module will manage the suricata service
+#   Defaults to true
+# 
 # [*service_ensure*]
 #   Choose whether suricata service is running or stopped
 #   Defaults to 'running'
@@ -87,11 +95,13 @@
 
 class suricata (
   String $ensure,
+  Boolean $package_manage,
   String $package_name,
   Stdlib::Absolutepath $config_dir,
   String $config_name,
   Stdlib::Absolutepath $log_dir,
   Enum['running', 'stopped'] $service_ensure,
+  Boolean $service_manage,
   String $service_name,
   Boolean $service_enable,
   String $service_provider,
@@ -131,7 +141,7 @@ class suricata (
   contain ::suricata::config
   contain ::suricata::service
 
-  Class['::suricata::install']->
-  Class['::suricata::config']~>
-  Class['::suricata::service']
+  Class['::suricata::install']
+  -> Class['::suricata::config']
+  ~> Class['::suricata::service']
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,37 +1,40 @@
 class suricata::install {
 
-  case $::osfamily {
-    'RedHat': {
-      if $::suricata::configure_epel {
-        $pkg_require = Package['epel-release']
+  if $::suricata::package_manage {
 
-        package { 'epel-release':
-          ensure => installed,
-        }
-      } else { $pkg_require = undef }
-    }
-    'Debian': {
-      if $::operatingsystem == 'ubuntu' {
-        if $::suricata::ppa_source {
-          $pkg_require = Apt::Ppa[$::suricata::ppa_source]
+    case $::osfamily {
+      'RedHat': {
+        if $::suricata::configure_epel {
+          $pkg_require = Package['epel-release']
 
-          include ::apt
-          apt::ppa { $::suricata::ppa_source: 
-            package_manage => true,
+          package { 'epel-release':
+            ensure => installed,
           }
-        }
-      } else { $pkg_require = undef }
+        } else { $pkg_require = undef }
+      }
+      'Debian': {
+        if $::operatingsystem == 'ubuntu' {
+          if $::suricata::ppa_source {
+            $pkg_require = Apt::Ppa[$::suricata::ppa_source]
+
+            include ::apt
+            apt::ppa { $::suricata::ppa_source:
+              package_manage => true,
+            }
+          }
+        } else { $pkg_require = undef }
+      }
+      default: {
+        $pkg_require = undef
+
+        notice("Your operating system: ${::osfamily} is not support")
+      }
+
     }
-    default: {
-      $pkg_require = undef
 
-      notice("Your operating system: ${::osfamily} is not support")
+    package { $::suricata::package_name:
+      ensure  => $::suricata::ensure,
+      require => $pkg_require,
     }
-
-  }
-
-  package { $::suricata::package_name:
-    ensure  => $::suricata::ensure,
-    require => $pkg_require,
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -20,7 +20,7 @@ class suricata::service {
           content => epp('suricata/suricata.service.epp'),
         }
 
-        exec { 'Daemon-reload':
+        exec { 'suriata-daemon-reload':
           command     => '/bin/systemctl daemon-reload',
           subscribe   => File["${systemd_path}/suricata.service"],
           refreshonly => true,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,42 +1,45 @@
 class suricata::service {
 
-  case $::suricata::service_provider {
-    'systemd': {
-      
-      $systemd_path = $::operatingsystem ? {
-        /(Ubuntu|Debian)/ => '/lib/systemd/system',
-        default           => '/usr/lib/systemd/system',
+  if $::suricata::service_manage {
+
+    case $::suricata::service_provider {
+      'systemd': {
+
+        $systemd_path = $::operatingsystem ? {
+          /(Ubuntu|Debian)/ => '/lib/systemd/system',
+          default           => '/usr/lib/systemd/system',
+        }
+
+        $service_require = File["${systemd_path}/suricata.service"]
+
+        file { "${systemd_path}/suricata.service":
+          ensure  => file,
+          owner   => 'root',
+          group   => 'root',
+          mode    => '0644',
+          content => epp('suricata/suricata.service.epp'),
+        }
+
+        exec { 'Daemon-reload':
+          command     => '/bin/systemctl daemon-reload',
+          subscribe   => File["${systemd_path}/suricata.service"],
+          refreshonly => true,
+          notify      => Service[$::suricata::service_name],
+        }
       }
+      default: {
+        $service_require = undef
 
-      $service_require = File["${systemd_path}/suricata.service"]
-
-      file { "${systemd_path}/suricata.service":
-        ensure  => file,
-        owner   => 'root',
-        group   => 'root',
-        mode    => '0644',
-        content => epp('suricata/suricata.service.epp'),
-      }
-
-      exec { 'Daemon-reload':
-        command     => '/bin/systemctl daemon-reload',
-        subscribe   => File["${systemd_path}/suricata.service"],
-        refreshonly => true,
-        notify      => Service[$::suricata::service_name],
+        notice("Your ${::suricata::service_provider} is not supported")
       }
     }
-    default: {
-      $service_require = undef
 
-      notice("Your ${::suricata::service_provider} is not supported")
+    service { $::suricata::service_name:
+      ensure   => $::suricata::service_ensure,
+      enable   => $::suricata::service_enable,
+      provider => $::suricata::service_provider,
+      require  => $service_require,
     }
-  }
 
-  service { $::suricata::service_name:
-    ensure   => $::suricata::service_ensure,
-    enable   => $::suricata::service_enable,
-    provider => $::suricata::service_provider,
-    require  => $service_require,
   }
-
 }


### PR DESCRIPTION
Add option for this module not to manage package installation and service handling. puppet-lint is executed to fix linting issues.